### PR TITLE
Enable ingress to grafana via istio ingress

### DIFF
--- a/install/kubernetes/addons/grafana.yaml
+++ b/install/kubernetes/addons/grafana.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 3000
     protocol: TCP
-    name: grafana
+    name: http
   selector:
     app: grafana
 ---


### PR DESCRIPTION
Rename port for `grafana` service in `install/kubernetes/addons/grafana.yml`
from `grafana` to `http` so that one can have istio ingress to grafana. See
[here](https://github.com/istio/issues/issues/20#issuecomment-308852372)